### PR TITLE
Parameter controls

### DIFF
--- a/Relaxation/Relaxation.cfc
+++ b/Relaxation/Relaxation.cfc
@@ -300,6 +300,10 @@ component
 					StructAppend(resource[resourceKey].WrapSimpleValues, arguments.Config.WrapSimpleValues, false);
 					StructAppend(resource[resourceKey].Arguments, arguments.Config.Arguments, false);
 					StructAppend(resource[resourceKey].Arguments.MergeScopes, arguments.Config.Arguments.MergeScopes, false);
+					if ( StructKeyExists(resource[resourceKey], "DefaultArguments") && IsStruct(resource[resourceKey].DefaultArguments) ) {
+						/* Remap legacy config to new position. */
+						resource[resourceKey].Arguments["Defaults"] = resource[resourceKey].DefaultArguments;
+					}
 				}
 			}
 			/* Add resources with arguments in the path to the bottom. */
@@ -355,7 +359,7 @@ component
 	**/
 	private struct function gatherRequestArguments( required struct ResourceMatch, string RequestBody = "", struct URLScope = {}, struct FormScope = {} ) {
 		/* Grab the DefaultArguments if they exist. */
-		var DefaultArgs = isNull(arguments.ResourceMatch.DefaultArguments) ? {} : arguments.ResourceMatch.DefaultArguments;
+		var DefaultArgs = isNull(arguments.ResourceMatch.Arguments.Defaults) ? {} : arguments.ResourceMatch.Arguments.Defaults;
 		/* Get the arguments from the URIs (e.g. /product/321 to ProductID=321) */
 		var PathValues = {};
 		if ( ReFindNoCase("[{}]", ResourceMatch.Pattern) ) {

--- a/UnitTests/RestConfig.json
+++ b/UnitTests/RestConfig.json
@@ -16,6 +16,17 @@
 				}
 			}
 		}
+		,"/product/inactive": {
+			"GET": {
+				"Bean": "ProductService"
+				,"Method": "getAllProducts"
+				,"Arguments": {
+					"Defaults": {
+						"Active": 0
+					}
+				}
+			}
+		}
 		,"/product/colors": {
 			"GET": {
 				"Bean": "ProductService"

--- a/UnitTests/test_Relaxation.cfc
+++ b/UnitTests/test_Relaxation.cfc
@@ -160,12 +160,18 @@ component extends="mxunit.framework.TestCase" {
 		assertEquals("red", args.Color);
 		assertEquals(FormScope.FormTestArg, args.FormTestArg);
 		
-		/* Run a request that has "DefaultArguments" configured. */
+		/* LEGACY: Run a request that has "DefaultArguments" configured. */
 		var Match = variables.RestFramework.findResourceConfig("/product/all-active","GET");
 		var args = variables.RestFramework.gatherRequestArguments(ResourceMatch = Match, RequestBody = "", URLScope = {}, FormScope = {} );
 		//debug(args);
 		assertEquals(1, args.Active);
 		assertEquals('Available', args.Status);
+		
+		/* Run a request that has "Arguments.Defaults" configured. */
+		var Match = variables.RestFramework.findResourceConfig("/product/inactive","GET");
+		var args = variables.RestFramework.gatherRequestArguments(ResourceMatch = Match, RequestBody = "", URLScope = {}, FormScope = {} );
+		//debug(args);
+		assertEquals(0, args.Active);
 	}
 	
 	/**


### PR DESCRIPTION
Updates to allow the following:
- Configure the argument name for the HTTP request body
  value that is passed to your service method. (Still defaults to
  "Payload".)
- Specify which scopes are merged into the argument collection passed to your service methods.
- Move default arguments into the new "Arguments" config struct. (retained legacy support)
