### PR TITLE
Add response text for 403

### DIFF
--- a/Relaxation/Relaxation.cfc
+++ b/Relaxation/Relaxation.cfc
@@ -130,15 +130,15 @@ component
 			/* Provide appropriate error responses. */
 			switch(result.Error) {
 				case "NotAuthorized": {
-					var response = {
+					result["Response"] = {
 						"status" = 403,
 						"statusText" = 'Forbidden',
-						"responseText" = 'The user does not have access to this resource'
+						"responseText" = result.ErrorMessage
 					};
 					break;
 				}
 				case "ResourceNotFound": {
-					var response = {
+					result["Response"] = {
 						"status" = 404,
 						"statusText" = 'Not Found',
 						"responseText" = result.ErrorMessage
@@ -147,7 +147,7 @@ component
 				}
 				case "VerbNotFound": {
 					variables.HTTPUtil.setResponseHeader('Allow', result.AllowedVerbs);
-					var response = {
+					result["Response"] = {
 						"status" = 405,
 						"statusText" = 'Method Not Allowed',
 						"responseText" = result.ErrorMessage
@@ -155,7 +155,7 @@ component
 					break;
 				}
 				default: {
-					var response = {
+					result["Response"] = {
 						"status" = 500,
 						"statusText" = 'Unknown Error Type',
 						"responseText" = result.ErrorMessage
@@ -166,8 +166,8 @@ component
 			/* Tell the client we are sending JSON. */
 			variables.HTTPUtil.setResponseContentType('application/json');
 			/* Output the response */
-			variables.HTTPUtil.setResponseStatus(response.status, response.statusText);
-			writeOutput( SerializeJSON(response) );
+			variables.HTTPUtil.setResponseStatus(result.Response.status, result.Response.statusText);
+			writeOutput( SerializeJSON(result.Response) );
 		}
 		result["Rendered"] = true;
 		return result;
@@ -235,6 +235,7 @@ component
 			if ( !authorize(authArg) ) {
 				result.Success = false;
 				result.Error = "NotAuthorized";
+				result.ErrorMessage = "The user does not have access to this resource";
 				return result;
 			}
 		}

--- a/UnitTests/test_Relaxation.cfc
+++ b/UnitTests/test_Relaxation.cfc
@@ -501,6 +501,32 @@ component extends="mxunit.framework.TestCase" {
 	}
 	
 	/**
+	* @hint "I test that throwing specific errorcodes are mapped to specific http status codes."
+	**/
+	public void function thrown_errors_should_map_correctly() {
+		var httpUtil = mock();
+		httpUtil.setResponseHeader('{string}', '{string}').returns();
+		httpUtil.setResponseContentType('{string}').returns();
+		httpUtil.setResponseStatus(403, 'Forbidden').returns();
+		httpUtil.setResponseStatus(404, 'Not Found').returns();
+		variables.RestFramework.setHTTPUtil( httpUtil );
+		
+		/* Mock a known request state to test status code mapping. */
+		InjectMethod( variables.RestFramework, this, 'return403Result', 'processRequest' );
+		/* Call handleRequest. */
+		var result = variables.RestFramework.handleRequest( '/na' );
+		httpUtil.verify().setResponseStatus(403, 'Forbidden');
+		AssertEquals(return403Result().ErrorMessage, result.response.responseText);
+		
+		/* Mock a known request state to test status code mapping. */
+		InjectMethod( variables.RestFramework, this, 'return404Result', 'processRequest' );
+		/* Call handleRequest. */
+		var result2 = variables.RestFramework.handleRequest( '/na' );
+		httpUtil.verify().setResponseStatus(404, 'Not Found');
+		AssertEquals(return404Result().ErrorMessage, result2.response.responseText);
+	}
+	
+	/**
 	 * @hint I test that the WrapSimpleValues portion of the configuration works properly
 	 **/
 	public void function wrap_simple_values_config_should_work() {
@@ -706,6 +732,36 @@ component extends="mxunit.framework.TestCase" {
 	**/
 	private struct function getFrameworkConfig() {
 		return DeserializeJSON(fileRead(expandPath(variables.ConfigPath)));
+	}
+	
+	/**
+	* @hint "I return a result that should trigger a 403."
+	**/
+	private struct function return403Result() {
+		var result = {
+			"Success" = false
+			,"Output" = ""
+			,"Error" = "NotAuthorized"
+			,"ErrorMessage" = "You can't touch this!"
+			,"AllowedVerbs" = ""
+			,"CacheHeaderSeconds" = ""
+		};
+		return result;
+	}
+	
+	/**
+	* @hint "I return a result that should trigger a 404."
+	**/
+	private struct function return404Result() {
+		var result = {
+			"Success" = false
+			,"Output" = ""
+			,"Error" = "ResourceNotFound"
+			,"ErrorMessage" = "Where's the beef!"
+			,"AllowedVerbs" = ""
+			,"CacheHeaderSeconds" = ""
+		};
+		return result;
 	}
 	
 	/**


### PR DESCRIPTION
This is a minor cleanup to allow your service method to throw a specific error code with a specific error message and have them both map appropriately.
