### PR TITLE
Option to not serialize values

### DIFF
--- a/UnitTests/test_Relaxation.cfc
+++ b/UnitTests/test_Relaxation.cfc
@@ -970,6 +970,12 @@ component extends="mxunit.framework.TestCase" {
 			,"AllowedVerbs" = ""
 			,"CacheHeaderSeconds" = ""
 		};
+		result["Resource"] = {
+			"Located" = true
+			,"SerializeValues" = {
+				"enabled" = true
+			}
+		};
 		return result;
 	}
 	
@@ -985,6 +991,12 @@ component extends="mxunit.framework.TestCase" {
 			,"AllowedVerbs" = ""
 			,"CacheHeaderSeconds" = ""
 		};
+		result["Resource"] = {
+			"Located" = true
+			,"SerializeValues" = {
+				"enabled" = true
+			}
+		};
 		return result;
 	}
 	
@@ -999,6 +1011,12 @@ component extends="mxunit.framework.TestCase" {
 			,"ErrorMessage" = "Where's the beef!"
 			,"AllowedVerbs" = ""
 			,"CacheHeaderSeconds" = ""
+		};
+		result["Resource"] = {
+			"Located" = true
+			,"SerializeValues" = {
+				"enabled" = true
+			}
 		};
 		return result;
 	}


### PR DESCRIPTION
We had a use case at work to proxy an API that was returning the exact JSON that we wanted our API to return. De-serializing the API response and then re-serializing it would have been unnecessary and probably would have resulted in CF serialization errors.

This adds a feature that allows you to configure a method to not serialize the response (allowing your method to simply return the JSON string you want).

Example config:
```
"/some/collection": {
	"GET": {
		"Bean": "SomeController",
		"Method": "returnsJson",
		"SerializeValues": {
			"enabled": false
		}
	}
},
```