### PR TITLE
Develop

### DIFF
--- a/Relaxation/Relaxation.cfc
+++ b/Relaxation/Relaxation.cfc
@@ -172,6 +172,22 @@ component
 					};
 					break;
 				}
+				case "ConflictError": {
+					result["Response"] = {
+						"status" = 409,
+						"statusText" = 'Conflict',
+						"responseText" = result.ErrorMessage
+					};
+					break;
+				}
+				case "ServerError": {
+					result["Response"] = {
+						"status" = 500,
+						"statusText" = 'Internal Server Error',
+						"responseText" = result.ErrorMessage
+					};
+					break;
+				}
 				default: {
 					result["Response"] = {
 						"status" = 500,
@@ -287,7 +303,7 @@ component
 			result.Success = false;
 			result.ErrorMessage = e.Message;
 			/* Allow called methods to throw special ErrorCodes to get specific HTTP status codes. */
-			if ( ListFindNoCase("NotAuthorized,ResourceNotFound,ClientError", e.ErrorCode) ) {
+			if ( ListFindNoCase("NotAuthorized,ResourceNotFound,ClientError,ConflictError,ServerError", e.ErrorCode) ) {
 				result.Error = e.ErrorCode;
 				return result;
 			}

--- a/UnitTests/test_Relaxation.cfc
+++ b/UnitTests/test_Relaxation.cfc
@@ -923,6 +923,7 @@ component extends="mxunit.framework.TestCase" {
 	**/
 	private any function getHttpUtil() {
 		var httpUtil = mock();
+		httpUtil.getRequestHeaders().returns({});
 		httpUtil.setResponseHeader('{string}', '{string}').returns();
 		httpUtil.setResponseContentType('{string}').returns();
 		httpUtil.setResponseStatus(400, 'Bad Request').returns();
@@ -972,6 +973,9 @@ component extends="mxunit.framework.TestCase" {
 		};
 		result["Resource"] = {
 			"Located" = true
+			,"CrossOrigin" = {
+				"enabled" = true
+			}
 			,"SerializeValues" = {
 				"enabled" = true
 			}
@@ -993,6 +997,9 @@ component extends="mxunit.framework.TestCase" {
 		};
 		result["Resource"] = {
 			"Located" = true
+			,"CrossOrigin" = {
+				"enabled" = true
+			}
 			,"SerializeValues" = {
 				"enabled" = true
 			}
@@ -1014,6 +1021,9 @@ component extends="mxunit.framework.TestCase" {
 		};
 		result["Resource"] = {
 			"Located" = true
+			,"CrossOrigin" = {
+				"enabled" = true
+			}
 			,"SerializeValues" = {
 				"enabled" = true
 			}


### PR DESCRIPTION
After this PR is merged, I'll release 1.3.0. These are updates we have been using at work and are now getting ported back upstream.

Updates include:
* Option to enable/disable serialization (to support returning a string of JSON from a method)
* Update to CORS implementation so that non-success status codes can also be CORS compliant (e.g. 400, 404)
* Added more "ErrorCode"s that can be thrown to result in specific non-2XX http response statuses.