### PR TITLE
Allow xml response

### DIFF
--- a/Relaxation/Relaxation.cfc
+++ b/Relaxation/Relaxation.cfc
@@ -128,8 +128,13 @@ component
 				variables.HTTPUtil.setResponseHeader('Expires', variables.HTTPUtil.formatHTTPDate(httpexpires));
 			}
 			if ( len(trim(result.Output)) > 0 ) {
-				/* Tell the client we are sending JSON. */
-				variables.HTTPUtil.setResponseContentType('application/json');
+				if ( IsJson(result.Output) ) {
+					/* Tell the client we are responding with JSON. */
+					variables.HTTPUtil.setResponseContentType('application/json');
+				} else if ( IsXml(result.Output) ) {
+					/* Tell the client we are responding with XML. */
+					variables.HTTPUtil.setResponseContentType('text/xml');
+				}
 				/* Give'em what they asked for. */
 				writeOutput( result.Output );
 			} else {
@@ -314,6 +319,7 @@ component
 				rethrow;
 			}
 		}
+
 		if ( IsDefined("methodResult") ) {
 			if ( resource.SerializeValues.enabled ) {
 				if( IsSimpleValue(methodResult) && resource.WrapSimpleValues.enabled ) {

--- a/Relaxation/Relaxation.cfc
+++ b/Relaxation/Relaxation.cfc
@@ -139,6 +139,14 @@ component
 		} else {
 			/* Provide appropriate error responses. */
 			switch(result.Error) {
+				case "ClientError": {
+					result["Response"] = {
+						"status" = 400,
+						"statusText" = 'Bad Request',
+						"responseText" = result.ErrorMessage
+					};
+					break;
+				}
 				case "NotAuthorized": {
 					result["Response"] = {
 						"status" = 403,
@@ -160,14 +168,6 @@ component
 					result["Response"] = {
 						"status" = 405,
 						"statusText" = 'Method Not Allowed',
-						"responseText" = result.ErrorMessage
-					};
-					break;
-				}
-				case "ClientError": {
-					result["Response"] = {
-						"status" = 400,
-						"statusText" = 'Bad Request',
 						"responseText" = result.ErrorMessage
 					};
 					break;

--- a/UnitTests/ProductService.cfc
+++ b/UnitTests/ProductService.cfc
@@ -31,6 +31,22 @@ component displayname="Testing Service" hint="I am a simple service to test requ
 		return {};
 	}
 	
+	/**
+	* @hint "I get XML representing a product by its ID"
+	**/
+	public string function getProductXmlByID( string ProductID ) {
+		var product = getProductByID(ProductID = arguments.ProductID);
+		if (StructIsEmpty(product)) {
+			return '<product></product>';
+		}
+		return '<product>
+			<ProductID>#product.ProductID#</ProductID>
+			<Name>#product.Name#</Name>
+			<Price>#product.Price#</Price>
+			<Vendor>#product.Vendor#</Vendor>
+		</product>';
+	}
+	
 	public string function getProductPrice( string ProductID ) {
 		for (var product in variables.Products) {
 			if (product.ProductID == arguments.ProductID) {

--- a/UnitTests/RestConfig.json
+++ b/UnitTests/RestConfig.json
@@ -43,6 +43,15 @@
 				,"Method": "saveProduct"
 			}
 		}
+		,"/product/{ProductID}/xml": {
+			"GET": {
+				"Bean": "ProductService"
+				,"Method": "getProductXmlByID"
+				,"SerializeValues": {
+					"enabled": false
+				}
+			}
+		}
 		,"/product/{ProductID}/colors": {
 			"GET": {
 				"Bean": "ProductService"

--- a/UnitTests/test_Relaxation.cfc
+++ b/UnitTests/test_Relaxation.cfc
@@ -457,19 +457,26 @@ component extends="mxunit.framework.TestCase" {
 	* @hint "I test handleRequest."
 	**/
 	public void function handleRequest_should_work() {
-		var httpUtil = variables.RestFramework.getHTTPUtil();
-		injectMethod(local.httpUtil, this, "doNothing", "setResponseStatus");
-		injectMethod(local.httpUtil, this, "doNothing", "setResponseContentType");
+		var httpUtil = getHttpUtil();
+		variables.RestFramework.setHTTPUtil( httpUtil );
 		/* Test good response */
 		var result = variables.RestFramework.handleRequest( Path = "/product/1", Verb = "GET", RequestBody = "", URLScope = {}, FormScope = {});
 		assertIsStruct(result);
 		assertEquals(true, result.Success);
 		assertEquals(true, result.Rendered);
+		httpUtil.verifyTimes(1).setResponseContentType('application/json');
 		/* Test bad response */
 		result = variables.RestFramework.handleRequest( Path = "/product/this/will/never/work", Verb = "GET", RequestBody = "", URLScope = {}, FormScope = {});
 		assertIsStruct(result);
 		assertEquals(false, result.Success);
 		assertEquals(true, result.Rendered);
+		httpUtil.verifyTimes(2).setResponseContentType('application/json');
+		/* Test good (XML) response */
+		result = variables.RestFramework.handleRequest( Path = "/product/1/xml", Verb = "GET", RequestBody = "", URLScope = {}, FormScope = {});
+		assertIsStruct(result);
+		assertEquals(true, result.Success);
+		assertEquals(true, result.Rendered);
+		httpUtil.verifyTimes(1).setResponseContentType('text/xml');
 	}
 	
 	/**
@@ -939,7 +946,8 @@ component extends="mxunit.framework.TestCase" {
 		var httpUtil = mock();
 		httpUtil.getRequestHeaders().returns({});
 		httpUtil.setResponseHeader('{string}', '{string}').returns();
-		httpUtil.setResponseContentType('{string}').returns();
+		httpUtil.setResponseContentType('application/json').returns();
+		httpUtil.setResponseContentType('text/xml').returns();
 		httpUtil.setResponseStatus(400, 'Bad Request').returns();
 		httpUtil.setResponseStatus(403, 'Forbidden').returns();
 		httpUtil.setResponseStatus(404, 'Not Found').returns();

--- a/UnitTests/test_Relaxation.cfc
+++ b/UnitTests/test_Relaxation.cfc
@@ -698,23 +698,37 @@ component extends="mxunit.framework.TestCase" {
 		/* Mock a known request state to test status code mapping. */
 		InjectMethod( variables.RestFramework, this, 'return400Result', 'processRequest' );
 		/* Call handleRequest. */
-		var result = variables.RestFramework.handleRequest( '/na' );
+		var result400 = variables.RestFramework.handleRequest( '/na' );
 		httpUtil.verify().setResponseStatus(400, 'Bad Request');
-		AssertEquals(return400Result().ErrorMessage, result.response.responseText);
+		AssertEquals(return400Result().ErrorMessage, result400.response.responseText);
 		
 		/* Mock a known request state to test status code mapping. */
 		InjectMethod( variables.RestFramework, this, 'return403Result', 'processRequest' );
 		/* Call handleRequest. */
-		var result = variables.RestFramework.handleRequest( '/na' );
+		var result403 = variables.RestFramework.handleRequest( '/na' );
 		httpUtil.verify().setResponseStatus(403, 'Forbidden');
-		AssertEquals(return403Result().ErrorMessage, result.response.responseText);
+		AssertEquals(return403Result().ErrorMessage, result403.response.responseText);
 		
 		/* Mock a known request state to test status code mapping. */
 		InjectMethod( variables.RestFramework, this, 'return404Result', 'processRequest' );
 		/* Call handleRequest. */
-		var result2 = variables.RestFramework.handleRequest( '/na' );
+		var result404 = variables.RestFramework.handleRequest( '/na' );
 		httpUtil.verify().setResponseStatus(404, 'Not Found');
-		AssertEquals(return404Result().ErrorMessage, result2.response.responseText);
+		AssertEquals(return404Result().ErrorMessage, result404.response.responseText);
+		
+		/* Mock a known request state to test status code mapping. */
+		InjectMethod( variables.RestFramework, this, 'return409Result', 'processRequest' );
+		/* Call handleRequest. */
+		var result409 = variables.RestFramework.handleRequest( '/na' );
+		httpUtil.verify().setResponseStatus(409, 'Conflict');
+		AssertEquals(return409Result().ErrorMessage, result409.response.responseText);
+		
+		/* Mock a known request state to test status code mapping. */
+		InjectMethod( variables.RestFramework, this, 'return500Result', 'processRequest' );
+		/* Call handleRequest. */
+		var result500 = variables.RestFramework.handleRequest( '/na' );
+		httpUtil.verify().setResponseStatus(500, 'Internal Server Error');
+		AssertEquals(return500Result().ErrorMessage, result500.response.responseText);
 	}
 	
 	/**
@@ -929,6 +943,8 @@ component extends="mxunit.framework.TestCase" {
 		httpUtil.setResponseStatus(400, 'Bad Request').returns();
 		httpUtil.setResponseStatus(403, 'Forbidden').returns();
 		httpUtil.setResponseStatus(404, 'Not Found').returns();
+		httpUtil.setResponseStatus(409, 'Conflict').returns();
+		httpUtil.setResponseStatus(500, 'Internal Server Error').returns();
 		return httpUtil;
 	}
 	
@@ -1016,6 +1032,54 @@ component extends="mxunit.framework.TestCase" {
 			,"Output" = ""
 			,"Error" = "ResourceNotFound"
 			,"ErrorMessage" = "Where's the beef!"
+			,"AllowedVerbs" = ""
+			,"CacheHeaderSeconds" = ""
+		};
+		result["Resource"] = {
+			"Located" = true
+			,"CrossOrigin" = {
+				"enabled" = true
+			}
+			,"SerializeValues" = {
+				"enabled" = true
+			}
+		};
+		return result;
+	}
+	
+	/**
+	* @hint "I return a result that should trigger a 409."
+	**/
+	private struct function return409Result() {
+		var result = {
+			"Success" = false
+			,"Output" = ""
+			,"Error" = "ConflictError"
+			,"ErrorMessage" = "Conflict!"
+			,"AllowedVerbs" = ""
+			,"CacheHeaderSeconds" = ""
+		};
+		result["Resource"] = {
+			"Located" = true
+			,"CrossOrigin" = {
+				"enabled" = true
+			}
+			,"SerializeValues" = {
+				"enabled" = true
+			}
+		};
+		return result;
+	}
+	
+	/**
+	* @hint "I return a result that should trigger a 500."
+	**/
+	private struct function return500Result() {
+		var result = {
+			"Success" = false
+			,"Output" = ""
+			,"Error" = "ServerError"
+			,"ErrorMessage" = "Something went wrong!"
 			,"AllowedVerbs" = ""
 			,"CacheHeaderSeconds" = ""
 		};


### PR DESCRIPTION
With the previous addition of the SerializeValues config option, you could wire up a route to a method that returned "string" and the framework would let your response pass through. 

I originally used this as a way to proxy through to another service that was already returning JSON (so that it didn't have to get deserialized just to get serialized again.)

Now, I would like to return XML. I never anticipated needing this. But, I'm working with a service that is going to perform a webhook and expect XML in response. These updates, allow me to wire that route up to a function that will return "string" (that is XML) and the framework will now respond with the correct "Content-Type" header.

