### PR TITLE
Updates to allow authorization method to throw special http ErrorCodes

### DIFF
--- a/Relaxation/Relaxation.cfc
+++ b/Relaxation/Relaxation.cfc
@@ -276,33 +276,34 @@ component
 			/* They just wanted to know which verbs are supported. We're done. */
 			return result;	
 		}
+		result.CacheHeaderSeconds = StructKeyExists(resource, "CacheHeaderSeconds") ? resource.CacheHeaderSeconds : "";
+		/* Gather the arguments needed to call the method (and for auth methods). */
+		var args = gatherRequestArguments( argumentCollection = arguments, ResourceMatch = resource);
 		var authArg = {
+			"CallArgs" = args,
 			"Bean" = resource.Bean,
 			"Method" = resource.Method,
 			"Path" = resource.Path,
 			"Pattern" = resource.Pattern,
 			"Verb" = resource.Verb
 		};
-		if ( !IsNull(getBasicAuthCheckMethod()) ) {
-			if ( !basicAuthCredentialsPass( authArg ) ) {
-				variables.HTTPUtil.promptForBasicAuth( "REST API" );
-			}
-		}
-		if ( !IsNull(getAuthorizationMethod()) ) {
-			var authorize = getAuthorizationMethod();
-			if ( !authorize(authArg) ) {
-				result.Success = false;
-				result.Error = "NotAuthorized";
-				result.ErrorMessage = "You are not authorized to do this";
-				return result;
-			}
-		}
-		result.CacheHeaderSeconds = StructKeyExists(resource, "CacheHeaderSeconds") ? resource.CacheHeaderSeconds : "";
-		var bean = getMappedBean(resource.Bean);
-		/* Gather the arguments needed to call the method. */
-		var args = gatherRequestArguments( argumentCollection = arguments, ResourceMatch = resource);
 		/* Now call the method on the bean! */
 		try {
+			if ( !IsNull(getBasicAuthCheckMethod()) ) {
+				if ( !basicAuthCredentialsPass( authArg ) ) {
+					variables.HTTPUtil.promptForBasicAuth( "REST API" );
+				}
+			}
+			if ( !IsNull(getAuthorizationMethod()) ) {
+				var authorize = getAuthorizationMethod();
+				if ( !authorize(authArg) ) {
+					result.Success = false;
+					result.Error = "NotAuthorized";
+					result.ErrorMessage = "You are not authorized to do this";
+					return result;
+				}
+			}
+			var bean = getMappedBean(resource.Bean);
 			var methodResult = variables.cfmlFunctions.cfmlInvoke(bean, resource.Method, args);
 		} catch (Any e) {
 			result.Success = false;

--- a/Relaxation/Relaxation.cfc
+++ b/Relaxation/Relaxation.cfc
@@ -16,6 +16,7 @@ component
 	variables.Defaults = {
 		"Arguments" = {
 			"PayloadArgument" = "Payload"
+			,"PayloadRawArgument" = "PayloadRaw"
 			,"MergeScopes" = {
 				"Path" = true
 				,"Payload" = true
@@ -515,6 +516,8 @@ component
 		};
 		/* Insert payload with specified (or default) argument name. */
 		args[arguments.ResourceMatch.Arguments.PayloadArgument] = Payload;
+		/* Insert raw payload with specified (or default) argument name. */
+		args[arguments.ResourceMatch.Arguments.PayloadRawArgument] = trim(arguments.RequestBody);
 		/* Coalesce all the sources together. Use "overwrite" false and put the highest priority first.  */
 		if ( arguments.ResourceMatch.Arguments.MergeScopes.Path ) {
 			StructAppend(args, PathValues, false);	/* Path 1st */

--- a/Relaxation/Relaxation.cfc
+++ b/Relaxation/Relaxation.cfc
@@ -309,7 +309,7 @@ component
 			result.Success = false;
 			result.ErrorMessage = e.Message;
 			/* Allow called methods to throw special ErrorCodes to get specific HTTP status codes. */
-			if ( ListFindNoCase("NotAuthorized,ResourceNotFound,ClientError,ConflictError,ServerError", e.ErrorCode) ) {
+			if ( ListFindNoCase("NotAuthorized,ResourceNotFound,ClientError,ConflictError,ServerError,VerbNotFound", e.ErrorCode) ) {
 				result.Error = e.ErrorCode;
 				return result;
 			}

--- a/Relaxation/Relaxation.cfc
+++ b/Relaxation/Relaxation.cfc
@@ -247,7 +247,7 @@ component
 		if ( isNull(arguments.FormScope) && isDefined("FORM") && isStruct(FORM) ) {
 			arguments.FormScope = FORM;
 		}
-		if ( isNull(arguments.RequestBody) && isJSON(trim(ToString(GetHttpRequestData().Content))) ) {
+		if ( isNull(arguments.RequestBody) && len(trim(ToString(GetHttpRequestData().Content))) ) {
 			arguments.RequestBody = trim(ToString(GetHttpRequestData().Content));
 		}
 		var result = {

--- a/Relaxation/Relaxation.cfc
+++ b/Relaxation/Relaxation.cfc
@@ -441,6 +441,8 @@ component
 	* @hint "Give an resource path and verb, I will return the config object. This will contain everything that was in the (GET,PUT,POST,etc) key in the config."
 	**/
 	private struct function findResourceConfig( required string Path, required string Verb ) {
+		/* Remove extensions (e.g. .json, .xml, etc) */
+		arguments.Path = ReReplaceNoCase(arguments.Path, "\.[a-z]+$", "");
 		/* Add trailing slash to make matching easier. */
 		arguments.Path &= ( Right(trim(arguments.Path),1) EQ '/' ? '' : '/' );
 		var result = {

--- a/UnitTests/test_Relaxation.cfc
+++ b/UnitTests/test_Relaxation.cfc
@@ -39,6 +39,7 @@ component extends="mxunit.framework.TestCase" {
 		
 		AssertIsStruct(config.Resources[1].PUT.Arguments);
 		AssertEquals('Payload', config.Resources[1].PUT.Arguments.PayloadArgument);
+		AssertEquals('PayloadRaw', config.Resources[1].PUT.Arguments.PayloadRawArgument);
 		AssertTrue(config.Resources[1].PUT.Arguments.MergeScopes.Path);
 		AssertTrue(config.Resources[1].PUT.Arguments.MergeScopes.Payload);
 		AssertTrue(config.Resources[1].PUT.Arguments.MergeScopes.URL);
@@ -52,6 +53,7 @@ component extends="mxunit.framework.TestCase" {
 		var testConfig = '{
 			"Arguments": {
 				"PayloadArgument": "TestPayloadArg"
+				,"PayloadRawArgument": "TestPayloadRawArg"
 				,"MergeScopes": {
 					"Path": false
 					,"Payload": false
@@ -73,6 +75,7 @@ component extends="mxunit.framework.TestCase" {
 		
 		AssertIsStruct(config.Resources[1].PUT.Arguments);
 		AssertEquals('TestPayloadArg', config.Resources[1].PUT.Arguments.PayloadArgument);
+		AssertEquals('TestPayloadRawArg', config.Resources[1].PUT.Arguments.PayloadRawArgument);
 		AssertFalse(config.Resources[1].PUT.Arguments.MergeScopes.Path);
 		AssertFalse(config.Resources[1].PUT.Arguments.MergeScopes.Payload);
 		AssertFalse(config.Resources[1].PUT.Arguments.MergeScopes.URL);
@@ -86,6 +89,7 @@ component extends="mxunit.framework.TestCase" {
 		var testConfig = '{
 			"Arguments": {
 				"PayloadArgument": "TestPayloadArg"
+				,"PayloadRawArgument": "TestPayloadRawArg"
 				,"MergeScopes": {
 					"Path": true
 					,"Payload": true
@@ -99,6 +103,7 @@ component extends="mxunit.framework.TestCase" {
 						,"Method": "updateProduct"
 						,"Arguments": {
 							"PayloadArgument": "Product"
+							,"PayloadRawArgument": "ProductJson"
 							,"MergeScopes": {
 								"Payload": false
 							}
@@ -112,6 +117,7 @@ component extends="mxunit.framework.TestCase" {
 		
 		AssertIsStruct(config.Resources[1].PUT.Arguments);
 		AssertEquals('Product', config.Resources[1].PUT.Arguments.PayloadArgument);
+		AssertEquals('ProductJson', config.Resources[1].PUT.Arguments.PayloadRawArgument);
 		AssertTrue(config.Resources[1].PUT.Arguments.MergeScopes.Path);
 		AssertFalse(config.Resources[1].PUT.Arguments.MergeScopes.Payload);
 		AssertTrue(config.Resources[1].PUT.Arguments.MergeScopes.URL);
@@ -190,9 +196,10 @@ component extends="mxunit.framework.TestCase" {
 		var args = relaxationInstance.gatherRequestArguments(ResourceMatch = Match, RequestBody = '{"isActive":true, "color":"red"}', URLScope = {"urlArg":1}, FormScope = {"formArg":2} );
 		AssertIsStruct(args);
 		/* The config for this resource+verb is to NOT merge any scopes. */
-		AssertEquals(2, ListLen(StructKeyList(args)));
+		AssertEquals(3, ListLen(StructKeyList(args)));
 		AssertTrue(ListFindNoCase(StructKeyList(args),"ArgumentSources"));
 		AssertTrue(ListFindNoCase(StructKeyList(args),"Payload"));
+		AssertTrue(ListFindNoCase(StructKeyList(args),"PayloadRaw"));
 	}
 	
 	/**
@@ -616,6 +623,7 @@ component extends="mxunit.framework.TestCase" {
 						,"Method": "addProduct"
 						,"Arguments": {
 							"PayloadArgument": "NewProduct"
+							,"PayloadRawArgument": "NewProductJson"
 						}
 					}
 				}
@@ -629,6 +637,7 @@ component extends="mxunit.framework.TestCase" {
 						,"Method": "updateProduct"
 						,"Arguments": {
 							"PayloadArgument": "ExistingProduct"
+							,"PayloadRawArgument": "ExistingProductJson"
 						}
 					}
 				}
@@ -655,8 +664,11 @@ component extends="mxunit.framework.TestCase" {
 		AssertIsStruct(args);
 		AssertFalse(StructKeyExists(args,"Payload"), "Payload key found. It should not be there.");
 		AssertTrue(StructKeyExists(args,"NewProduct"), "Could not find expected arg key.");
+		AssertFalse(StructKeyExists(args,"PayloadRaw"), "PayloadRaw key found. It should not be there.");
+		AssertTrue(StructKeyExists(args,"NewProductJson"), "Could not find expected raw arg key.");
 		AssertIsStruct(args.NewProduct);
 		AssertEquals("red", args.NewProduct.color);
+		AssertEquals('{"isActive":true, "color":"red"}', args.NewProductJson);
 		
 		/* Test product item PUT arg mapping. */
 		var Match = relaxationInstance.findResourceConfig("/product/123","PUT");
@@ -664,8 +676,11 @@ component extends="mxunit.framework.TestCase" {
 		AssertIsStruct(args);
 		AssertFalse(StructKeyExists(args,"Payload"), "Payload key found. It should not be there.");
 		AssertTrue(StructKeyExists(args,"ExistingProduct"), "Could not find expected arg key.");
+		AssertFalse(StructKeyExists(args,"PayloadRaw"), "PayloadRaw key found. It should not be there.");
+		AssertTrue(StructKeyExists(args,"ExistingProductJson"), "Could not find expected raw arg key.");
 		AssertIsStruct(args.ExistingProduct);
 		AssertEquals("red", args.ExistingProduct.color);
+		AssertEquals('{"isActive":true, "color":"red"}', args.ExistingProductJson);
 	}
 	
 	/**

--- a/UnitTests/test_Relaxation.cfc
+++ b/UnitTests/test_Relaxation.cfc
@@ -681,6 +681,13 @@ component extends="mxunit.framework.TestCase" {
 		AssertIsStruct(args.ExistingProduct);
 		AssertEquals("red", args.ExistingProduct.color);
 		AssertEquals('{"isActive":true, "color":"red"}', args.ExistingProductJson);
+		
+		/* Test product (non-JSON) item PUT arg mapping. */
+		var Match = relaxationInstance.findResourceConfig("/product/123","PUT");
+		var args = relaxationInstance.gatherRequestArguments(ResourceMatch = Match, RequestBody = 'some non JSON stuff', URLScope = {}, FormScope = {} );
+		AssertIsStruct(args);
+		AssertTrue(StructKeyExists(args,"ExistingProductJson"), "Could not find expected raw arg key.");
+		AssertEquals('some non JSON stuff', args.ExistingProductJson);
 	}
 	
 	/**

--- a/UnitTests/test_Relaxation.cfc
+++ b/UnitTests/test_Relaxation.cfc
@@ -389,6 +389,13 @@ component extends="mxunit.framework.TestCase" {
 		assertEquals("ProductService", match.Bean);
 		assertEquals("getProductColors", match.Method);
 		assertEquals("GET,OPTIONS", match.AllowedVerbs);
+		/* Test static URL (w/ extension). */
+		var match = variables.RestFramework.findResourceConfig( "/product/colors.json", "GET" );
+		assertIsStruct(match);
+		assertEquals(true, match.located);
+		assertEquals("ProductService", match.Bean);
+		assertEquals("getProductColors", match.Method);
+		assertEquals("GET,OPTIONS", match.AllowedVerbs);
 		/* Test dynamic URL. */
 		var match = variables.RestFramework.findResourceConfig( "/product/1", "GET" );
 		assertIsStruct(match);

--- a/UnitTests/test_Relaxation.cfc
+++ b/UnitTests/test_Relaxation.cfc
@@ -202,18 +202,24 @@ component extends="mxunit.framework.TestCase" {
 		
 		/* First test without an Authorization Method. */
 		var result = variables.RestFramework.processRequest( Path = "/product/1", Verb = "GET", RequestBody = "", URLScope = {}, FormScope = {});
-		assertEquals(true, result.Success);
+		assertTrue(result.success, "Test w/ no auth should have returned true");
 		
-		/* Second, test with an auth method that WILL authorize. */
+		/* Second test with an auth method that WILL authorize. */
 		variables.RestFramework.setAuthorizationMethod( returnTrue );
 		var result = variables.RestFramework.processRequest( Path = "/product/1", Verb = "GET", RequestBody = "", URLScope = {}, FormScope = {});
-		assertEquals(true, result.Success);
+		assertTrue(result.success, "Test w/ passing auth should have returned true");
 		
-		/* Third, test with an auth method that WON'T authorize. */
+		/* Third test with an auth method that WON'T authorize. */
 		variables.RestFramework.setAuthorizationMethod( returnFalse );
 		var result = variables.RestFramework.processRequest( Path = "/product/1", Verb = "GET", RequestBody = "", URLScope = {}, FormScope = {});
-		assertEquals(false, result.Success);
+		assertFalse(result.success, "Test w/ failing auth should have returned false");
 		assertEquals("NotAuthorized", result.Error);
+
+		/* Fourth test with an auth method that throws Relaxation error code (ResourceNotFound) */
+		variables.RestFramework.setAuthorizationMethod( throwResourceNotFound );
+		var result = variables.RestFramework.processRequest( Path = "/product/1", Verb = "GET", RequestBody = "", URLScope = {}, FormScope = {});
+		assertFalse(result.success, "Test w/ auth that throws should have returned false");
+		assertEquals("ResourceNotFound", result.Error);
 	}
 	
 	/**
@@ -1115,6 +1121,17 @@ component extends="mxunit.framework.TestCase" {
 	**/
 	private boolean function returnTrue() {
 		return true;
+	}
+	
+	/**
+	* @hint "I throw error code ResourceNotFound."
+	**/
+	private boolean function throwResourceNotFound() {
+		Throw(
+			Type = "Relaxation.Testing",
+			ErrorCode = "ResourceNotFound",
+			Message = "For testing"
+		);
 	}
 	
 	/**


### PR DESCRIPTION
fixes #32 

Moving a little bit of code around to allow the following two things:

1. Authorization method will have access to call args (in particular I need route params).
2. Authorization method can throw Relaxation ErrorCodes like bean methods can to get particular statuses returned.