### PR TITLE
Added support for (429 Too Many Requests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you want to know more, checkout the [QuickStart Guide](https://github.com/cfc
 
 ## Requirements
 
-I have tested Relaxation on ACF (9 through 2016) and Railo 4. I suspect it _might_ work on CF8. But, it will likely not work on older versions of CF because it is written primarily in cfscript.
+I have tested Relaxation on ACF (9 through 2021) and Railo 4. I suspect it _might_ work on CF8. But, it will likely not work on older versions of CF because it is written primarily in cfscript.
 
 There are no external dependencies to use Relaxation.
 

--- a/Relaxation/Relaxation.cfc
+++ b/Relaxation/Relaxation.cfc
@@ -186,6 +186,14 @@ component
 					};
 					break;
 				}
+				case "TooManyRequests": {
+					result["Response"] = {
+						"status" = 429,
+						"statusText" = 'Too Many Requests',
+						"responseText" = result.ErrorMessage
+					};
+					break;
+				}
 				case "ServerError": {
 					result["Response"] = {
 						"status" = 500,

--- a/UnitTests/test_Relaxation.cfc
+++ b/UnitTests/test_Relaxation.cfc
@@ -766,6 +766,13 @@ component extends="mxunit.framework.TestCase" {
 		AssertEquals(return409Result().ErrorMessage, result409.response.responseText);
 		
 		/* Mock a known request state to test status code mapping. */
+		InjectMethod( variables.RestFramework, this, 'return429Result', 'processRequest' );
+		/* Call handleRequest. */
+		var result429 = variables.RestFramework.handleRequest( '/na' );
+		httpUtil.verify().setResponseStatus(429, 'Too Many Requests');
+		AssertEquals(return429Result().ErrorMessage, result429.response.responseText);
+		
+		/* Mock a known request state to test status code mapping. */
 		InjectMethod( variables.RestFramework, this, 'return500Result', 'processRequest' );
 		/* Call handleRequest. */
 		var result500 = variables.RestFramework.handleRequest( '/na' );
@@ -987,6 +994,7 @@ component extends="mxunit.framework.TestCase" {
 		httpUtil.setResponseStatus(403, 'Forbidden').returns();
 		httpUtil.setResponseStatus(404, 'Not Found').returns();
 		httpUtil.setResponseStatus(409, 'Conflict').returns();
+		httpUtil.setResponseStatus(429, 'Too Many Requests').returns();
 		httpUtil.setResponseStatus(500, 'Internal Server Error').returns();
 		return httpUtil;
 	}
@@ -1099,6 +1107,30 @@ component extends="mxunit.framework.TestCase" {
 			,"Output" = ""
 			,"Error" = "ConflictError"
 			,"ErrorMessage" = "Conflict!"
+			,"AllowedVerbs" = ""
+			,"CacheHeaderSeconds" = ""
+		};
+		result["Resource"] = {
+			"Located" = true
+			,"CrossOrigin" = {
+				"enabled" = true
+			}
+			,"SerializeValues" = {
+				"enabled" = true
+			}
+		};
+		return result;
+	}
+	
+	/**
+	* @hint "I return a result that should trigger a 429."
+	**/
+	private struct function return429Result() {
+		var result = {
+			"Success" = false
+			,"Output" = ""
+			,"Error" = "TooManyRequests"
+			,"ErrorMessage" = "Too many requests!"
 			,"AllowedVerbs" = ""
 			,"CacheHeaderSeconds" = ""
 		};


### PR DESCRIPTION
In order to add throttling to our API, I want Relaxation to support [(429 Too Many Requests)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) like it supports other error codes via throwing ErrorCodes.

These updates add that behavior.

![image](https://github.com/cfchris/Relaxation/assets/819847/88c62dc2-3e01-4199-8031-6fd03dfe2fef)
